### PR TITLE
Improve debugging, add timing information

### DIFF
--- a/lib/puppet_x/ldapquery.rb
+++ b/lib/puppet_x/ldapquery.rb
@@ -59,7 +59,6 @@ module PuppetX
         }
       end
 
-      Puppet.debug(conf)
       return conf
     end
 
@@ -73,8 +72,7 @@ module PuppetX
 
       conf = self.get_config()
 
-      Puppet.debug("Searching ldap base #{base} using #{@filter} for #{@attributes}")
-
+      start_time = Time.now.to_i
       ldap = Net::LDAP.new(conf)
       ldapfilter = Net::LDAP::Filter.construct(@filter)
 
@@ -87,9 +85,12 @@ module PuppetX
                     :time => 10) do |entry|
           entries << entry
         end
-        Puppet.debug(entries)
+        end_time = Time.now.to_i
+        Puppet.debug("Searching #{@base} for #{@attributes} using #{@filter} took #{end_time - start_time} seconds")
         return entries
-      rescue
+      rescue Exception => e
+        Puppet.debug('There was an error searching LDAP #{e.message}')
+        Puppet.debug('Returning empty array')
         return []
       end
     end

--- a/lib/puppet_x/ldapquery.rb
+++ b/lib/puppet_x/ldapquery.rb
@@ -72,7 +72,7 @@ module PuppetX
 
       conf = self.get_config()
 
-      start_time = Time.now.to_i
+      start_time = Time.now
       ldap = Net::LDAP.new(conf)
       ldapfilter = Net::LDAP::Filter.construct(@filter)
 
@@ -85,8 +85,10 @@ module PuppetX
                     :time => 10) do |entry|
           entries << entry
         end
-        end_time = Time.now.to_i
-        Puppet.debug("Searching #{@base} for #{@attributes} using #{@filter} took #{end_time - start_time} seconds")
+        end_time = Time.now
+        time_delta = sprintf('%.3f', end_time - start_time)
+
+        Puppet.debug("Searching #{@base} for #{@attributes} using #{@filter} took #{time_delta} seconds")
         return entries
       rescue Exception => e
         Puppet.debug('There was an error searching LDAP #{e.message}')


### PR DESCRIPTION
Ldap has the potential to slow down compiles if a search takes too long.
Here we add timing information to the debug output, so that in case of
question, we can at least have a method of determining the time a given
search took.