### PR TITLE
Return boolean false if the LDAP query function raises an exception.

### DIFF
--- a/lib/puppet_x/ldapquery.rb
+++ b/lib/puppet_x/ldapquery.rb
@@ -92,8 +92,8 @@ module PuppetX
         return entries
       rescue Exception => e
         Puppet.debug('There was an error searching LDAP #{e.message}')
-        Puppet.debug('Returning empty array')
-        return []
+        Puppet.debug('Returning false')
+        return false
       end
     end
 


### PR DESCRIPTION
- This would be useful to differentiate whether or not there was an issue connecting/querying the LDAP server or if the results were empty.
- I'm not sure if this is actually needed.