### PR TITLE
Always return an array for the values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,31 +8,9 @@ rvm:
   - 2.1.0
 script: bundle exec rake test
 env:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
-  - PUPPET_VERSION="~> 3.4.0"
-  - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
-matrix:
-  exclude:
-  # Ruby 1.9.3
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
-    
-  # Ruby 2.0.0
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
-    
-  # Ruby 2.1.0
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 3.8.3" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+  - PUPPET_VERSION="~> 4.2.3"
+  - PUPPET_VERSION="~> 4.3.2"
 sudo: false

--- a/lib/puppet_x/ldapquery.rb
+++ b/lib/puppet_x/ldapquery.rb
@@ -88,10 +88,10 @@ module PuppetX
         end_time = Time.now
         time_delta = sprintf('%.3f', end_time - start_time)
 
-        Puppet.debug("Searching #{@base} for #{@attributes} using #{@filter} took #{time_delta} seconds and returned #{entries.length} results")
+        Puppet.debug("ldapquery(): Searching #{@base} for #{@attributes} using #{@filter} took #{time_delta} seconds and returned #{entries.length} results")
         return entries
       rescue Exception => e
-        Puppet.debug('There was an error searching LDAP #{e.message}')
+        Puppet.debug("There was an error searching LDAP #{e.message}")
         Puppet.debug('Returning false')
         return false
       end
@@ -105,21 +105,15 @@ module PuppetX
         entry.each do |attribute, values|
 
           attr = attribute.to_s
-
-          if values.is_a? Array and values.size > 1
-            entry_data[attr] = []
-
-            values.each do |v|
-              entry_data[attr] << v.chomp
-            end
-          elsif values.is_a? Array and values.size == 1
-            entry_data[attr] = values[0].chomp
-          else
-            entry_data[attr] = values.chomp
+          value_data = []
+          Array(values).flatten.each do |v|
+            value_data << v.chomp
           end
+          entry_data[attr] = value_data
         end
         data << entry_data
       end
+      Puppet.debug(data)
       return data
     end
 

--- a/spec/unit/ldapquery_spec.rb
+++ b/spec/unit/ldapquery_spec.rb
@@ -28,13 +28,13 @@ describe 'PuppetX::LDAPquery' do
       filter = '(uid=zach)'
       attributes = ['uid']
 
-      wanted = [{"dn"=>"uid=zach,ou=users,dc=puppetlabs,dc=com", "uid"=>"zach"}]
+      wanted = [{"dn"=>["uid=zach,ou=users,dc=puppetlabs,dc=com"], "uid"=>["zach"]}]
       entries = Marshal.load(File.read("spec/fixtures/entries_single.obj"))
 
       l = PuppetX::LDAPquery.new(filter, attributes, base)
 
       expect(l).to receive(:get_entries).and_return(entries)
-      expect(l.results).to match(wanted)
+      expect(l.results).to eq(wanted)
     end
 
     context "a multivalued attribute is requested" do
@@ -42,35 +42,25 @@ describe 'PuppetX::LDAPquery' do
         filter = '(uid=zach)'
         attributes = ['objectClass']
 
-        wanted = [{"dn"=>"uid=zach,ou=users,dc=puppetlabs,dc=com",
-                  "objectclass"=> [
-                    "posixAccount",
-                    "shadowAccount",
-                    "inetOrgPerson",
-                    "puppetPerson",
-                    "ldapPublicKey",
-                    "top"]}]
+        wanted =[{"dn"=>["uid=zach,ou=users,dc=puppetlabs,dc=com"], "objectclass"=>["posixAccount", "shadowAccount", "inetOrgPerson", "puppetPerson", "ldapPublicKey", "top"]}]
 
         entries = Marshal.load(File.read("spec/fixtures/entries_objectClass.obj"))
 
         l = PuppetX::LDAPquery.new(filter, attributes, base)
         expect(l).to receive(:get_entries).and_return(entries)
-        expect(l.results).to match(wanted)
+        expect(l.results).to eq(wanted)
       end
       it 'should return the attributes without new lines' do
         filter = '(uid=zach)'
         attributes = ['sshPublicKey']
 
-        wanted = [{"dn"=>"uid=zach,ou=users,dc=puppetlabs,dc=com",
-                  "sshpublickey"=>
-        ["ssh-rsa AAAAB...1== user@somewhere",
-        "ssh-rsa AAAAB...2== user@somewhereelse"]}]
+        wanted = [{"dn"=>["uid=zach,ou=users,dc=puppetlabs,dc=com"], "sshpublickey"=>["ssh-rsa AAAAB...1== user@somewhere", "ssh-rsa AAAAB...2== user@somewhereelse"]}]
 
         entries = Marshal.load(File.read("spec/fixtures/entries_multivalue.obj"))
 
         l = PuppetX::LDAPquery.new(filter, attributes, base)
         expect(l).to receive(:get_entries).and_return(entries)
-        expect(l.results).to match(wanted)
+        expect(l.results).to eq(wanted)
       end
     end
   end


### PR DESCRIPTION
Previously, its impossible to know if the results you are working with
in the puppet manifest are in string or array form without counting
them.  This work ensures that an array is always returned, even if there
is only one item returned.

This is useful in situations where an attribute is commonly both
multi-valued and single-valued to avoid complext manifest code.